### PR TITLE
Send classification IDs to Usage Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ $RECYCLE.BIN/
 .vscode
 
 # static resources
-src/main/default/staticResources/coveoua
+src/main/default/staticresources/coveoua

--- a/src/main/default/classes/CaseAssistEndpoint.cls
+++ b/src/main/default/classes/CaseAssistEndpoint.cls
@@ -40,7 +40,7 @@ public with sharing class CaseAssistEndpoint {
                         'fields' => fieldsMap
                     }
                 );
-            return JSON.serialize(classifications.get('fields'));
+            return JSON.serialize(classifications);
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage());
         }

--- a/src/main/default/lwc/caseAssistEndpoint/caseAssistEndpoint.js
+++ b/src/main/default/lwc/caseAssistEndpoint/caseAssistEndpoint.js
@@ -12,12 +12,14 @@ export default class CaseAssistEndpoint {
    * @typedef {Object} Prediction
    * @property {Number} confidence A number between 0 and 1 representing the confidence of the prediction
    * @property {String} value The predicted value
+   * @property {String} id The unique ID of the prediction
    */
 
   /**
    * An object representing the CaseClassifications predictions response
    * @typedef {Object} PredictionResponse
-   * @property {Prediction[]} predictions And array of predicted values for a field.
+   * @property {Prediction[]} predictions An array of predicted values for a field.
+   * @property {String} responseId The ID of the response provided by the API.
    */
 
   /**
@@ -59,12 +61,19 @@ export default class CaseAssistEndpoint {
    */
 
   /**
+   * An object representing the document suggestions response
+   * @typedef {Object} DocumentSuggestionsResponse
+   * @property {Document[]} documents An array of suggested documents.
+   * @property {String} responseId The ID of the response provided by the API.
+   */
+
+  /**
    * Async method to call an Apex class to obtain Document Suggestions.
    * @param {String} subject The subject of the case being created
    * @param {String} description The description of the case being created.
    * @param {String} visitorId The visitorId to link the visit together for analytics reporting.
    *
-   * @return {Document[]} docSuggestionsData An array of documents returned as suggestions.
+   * @return {DocumentSuggestionsResponse} docSuggestionsData An array of documents returned as suggestions.
    */
   async fetchDocSuggestions(subject, description, visitorId) {
     try {

--- a/src/main/default/lwc/caseAssistFlow/caseAssistFlow.js
+++ b/src/main/default/lwc/caseAssistFlow/caseAssistFlow.js
@@ -29,7 +29,7 @@ export default class CaseAssistFlow extends LightningElement {
   @api subHeading = 'Select related categories';
 
   @track theCase = {};
-  @track fieldSuggestions = [];
+  @track fieldSuggestions = {};
 
   constructor() {
     super();
@@ -83,9 +83,9 @@ export default class CaseAssistFlow extends LightningElement {
 
   // Parse the data from the suggestions
   parseFieldSuggestions(suggestionsData) {
-    // TODO: store the lastResponseID from the API response.
-    // this.lastResponseId = suggestionsData.responseId?
-    this.fieldSuggestions = suggestionsData || {};
+    const data = suggestionsData || { responseId: '', fields: {} };
+    this.lastResponseId = data.responseId || '';
+    this.fieldSuggestions = data.fields || {};
   }
 
   // Returns the field suggestions specific to the reason field.
@@ -167,7 +167,7 @@ export default class CaseAssistFlow extends LightningElement {
   sendTicketClassificationClick(data) {
     this.analyticsUpdateTicketData();
     coveoua('svc:setAction', analyticsActionNames.TICKET_CLASSIFICATION_CLICK, {
-      classificationId: data.classificationId,
+      classificationId: data.id,
       responseId: this.lastResponseId,
       fieldName: data.fieldName,
       classification: {

--- a/src/main/default/lwc/caseAssistSuggestions/__tests__/caseAssistSuggestions.test.js
+++ b/src/main/default/lwc/caseAssistSuggestions/__tests__/caseAssistSuggestions.test.js
@@ -129,10 +129,12 @@ describe('c-case-assist-suggestions', () => {
     const handler = jest.fn();
     const expectedFieldName = 'bar';
     const expectedLabel = 'foo';
+    const expectedId = 'b84ed8ed-a7b1-502f-83f6-90132e68adef';
     const suggestions = [
       {
         label: expectedLabel,
-        value: 'foo'
+        value: 'foo',
+        id: expectedId
       }
     ];
 
@@ -148,7 +150,9 @@ describe('c-case-assist-suggestions', () => {
     const suggestionBadge = containerElement.querySelector('lightning-badge');
     suggestionBadge.dispatchEvent(new CustomEvent('click'));
     expect(handler).toHaveBeenCalled();
-    expect(handler.mock.calls[0][0].detail.fieldName).toBe(expectedFieldName);
-    expect(handler.mock.calls[0][0].detail.value).toBe(suggestions[0].label);
+    const eventDetail = handler.mock.calls[0][0].detail;
+    expect(eventDetail.fieldName).toBe(expectedFieldName);
+    expect(eventDetail.value).toBe(suggestions[0].label);
+    expect(eventDetail.id).toBe(suggestions[0].id);
   });
 });

--- a/src/main/default/lwc/caseAssistSuggestions/caseAssistSuggestions.html
+++ b/src/main/default/lwc/caseAssistSuggestions/caseAssistSuggestions.html
@@ -5,6 +5,7 @@
         key={suggestion.value}
         label={suggestion.value}
         onclick={handleSuggestionClick}
+        data-id={suggestion.id}
         data-confidence={suggestion.confidence}
         class="slds-badge_lightest"
       ></lightning-badge>

--- a/src/main/default/lwc/caseAssistSuggestions/caseAssistSuggestions.js
+++ b/src/main/default/lwc/caseAssistSuggestions/caseAssistSuggestions.js
@@ -13,7 +13,8 @@ export default class CaseAssistSuggestions extends LightningElement {
     const eventData = {
       fieldName: this.fieldName,
       value: event.target.label,
-      confidence: event.target.dataset.confidence
+      confidence: event.target.dataset.confidence,
+      id: event.target.dataset.id
     };
     this.dispatchEvent(new CustomEvent('selected', { detail: eventData }));
   }

--- a/src/main/default/lwc/documentSuggestions/__tests__/documentSuggestions.test.js
+++ b/src/main/default/lwc/documentSuggestions/__tests__/documentSuggestions.test.js
@@ -141,12 +141,23 @@ describe('c-document-suggestions', () => {
         Subject: 'foo',
         Description: 'bar'
       };
+
+      const expectedResponseId = '24a729a0-5a0d-45e5-b6c8-5425627d90a5';
+
       const element = createComponent((elem) => {
         elem.caseData = JSON.stringify(caseData);
+
+        CaseAssistEndpoint.mock.instances[0].fetchDocSuggestions.mockReturnValue(
+          {
+            documents: [MOCK_RESULT],
+            responseId: expectedResponseId
+          }
+        );
       });
 
       // Flush microtasks
       await flushPromises();
+
       const documentResultListNode = element.shadowRoot.querySelector(
         'c-documents-result-list'
       );
@@ -163,7 +174,7 @@ describe('c-document-suggestions', () => {
         analyticsActionNames.SUGGESTION_CLICK,
         {
           suggestionId: MOCK_RESULT.fields.permanentid,
-          responseId: undefined,
+          responseId: expectedResponseId,
           suggestion: {
             documentUri: MOCK_RESULT.clickUri,
             documentUriHash: MOCK_RESULT.fields.urihash,

--- a/src/main/default/lwc/documentSuggestions/documentSuggestions.js
+++ b/src/main/default/lwc/documentSuggestions/documentSuggestions.js
@@ -48,21 +48,23 @@ export default class DocumentSuggestions extends LightningElement {
 
   async fetchDocumentSuggestions() {
     try {
-      const docSuggestionsResponse = await this.endpoint.fetchDocSuggestions(
+      const docSuggestionsResponse = (await this.endpoint.fetchDocSuggestions(
         this._caseData.Subject,
         this._caseData.Description,
         this._caseData.visitorId || 'foo'
-      );
+      )) || { responseId: '', documents: [] };
+
+      this.lastResponseId = docSuggestionsResponse.responseId;
       if (
-        Array.isArray(docSuggestionsResponse) &&
-        docSuggestionsResponse.length > 0
+        Array.isArray(docSuggestionsResponse.documents) &&
+        docSuggestionsResponse.documents.length > 0
       ) {
-        this.lastResponseId = docSuggestionsResponse.responseId;
-        this.suggestedDocuments = docSuggestionsResponse;
+        this.suggestedDocuments = docSuggestionsResponse.documents;
       } else {
         this.showCaseDataErrorToast();
       }
     } catch (err) {
+      this.lastResponseId = '';
       this.suggestedDocuments = [];
       this.showCaseDataErrorToast();
       console.error(err);

--- a/src/main/default/lwc/documentSuggestions/documentSuggestions.js
+++ b/src/main/default/lwc/documentSuggestions/documentSuggestions.js
@@ -57,8 +57,7 @@ export default class DocumentSuggestions extends LightningElement {
         Array.isArray(docSuggestionsResponse) &&
         docSuggestionsResponse.length > 0
       ) {
-        // TODO: store the lastResponseID from the API response.
-        // this.lastResponseId = docSuggestionsResponse.responseId;
+        this.lastResponseId = docSuggestionsResponse.responseId;
         this.suggestedDocuments = docSuggestionsResponse;
       } else {
         this.showCaseDataErrorToast();


### PR DESCRIPTION
Now that classification IDs are returned from the Customer Service API (see [.../classify](https://platform.cloud.coveo.com/docs?urls.primaryName=Customer%20Service#/Suggestions/postClassify) call), this pull request updates the cookbook to retrieve the IDs and forward them to Usage Analytics through click events.

In addition, the `responseId` is now forwarded for document suggestions as well.