### PR TITLE
Fix to classifications Ids for docsuggestions

### DIFF
--- a/src/main/default/classes/CaseAssistEndpoint.cls
+++ b/src/main/default/classes/CaseAssistEndpoint.cls
@@ -81,7 +81,7 @@ public with sharing class CaseAssistEndpoint {
                         'fields' => fieldsMap
                     }
                 );
-            return JSON.serialize((List<Object>) result.get('documents'));
+            return JSON.serialize(result);
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage());
         }


### PR DESCRIPTION
We were not returning the correct data from the get document suggestions Apex call after the changes with the request Ids.

@lbergeron Can you please verify this is correct now? (I have checked and it seems like it's doing what it is supposed to do).