### PR TITLE
SFINT-4127 sectionTitle component added

### DIFF
--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>cookbook_SectionTitle</fullName>
+        <value>Section title</value>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Section title</shortDescription>
+    </labels>
+</CustomLabels>

--- a/src/main/default/lwc/sectionTitle/__test__/sectionTitle.test.js
+++ b/src/main/default/lwc/sectionTitle/__test__/sectionTitle.test.js
@@ -1,0 +1,39 @@
+import { createElement } from 'lwc';
+import SectionTitle from 'c/sectionTitle';
+
+function createTestComponent() {
+  const element = createElement('c-section-title', {
+    is: SectionTitle
+  });
+  document.body.appendChild(element);
+
+  return element;
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  // eslint-disable-next-line no-undef
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('c-section-title', () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it('should display the title text', async () => {
+    const element = createTestComponent();
+    const expectedTitle = 'Expected Title';
+    element.title = expectedTitle;
+
+    await flushPromises();
+    const titleNode = element.shadowRoot.querySelector(
+      'h2.slds-text-heading_small'
+    );
+    expect(titleNode).not.toBeNull();
+    expect(titleNode.textContent).toBe(expectedTitle);
+  });
+});

--- a/src/main/default/lwc/sectionTitle/__test__/sectionTitle.test.js
+++ b/src/main/default/lwc/sectionTitle/__test__/sectionTitle.test.js
@@ -16,6 +16,14 @@ function flushPromises() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+jest.mock(
+  '@salesforce/label/c.cookbook_SectionTitle',
+  () => ({ default: 'Section title' }),
+  {
+    virtual: true
+  }
+);
+
 describe('c-section-title', () => {
   afterEach(() => {
     // The jsdom instance is shared across test cases in a single file so reset the DOM
@@ -28,6 +36,18 @@ describe('c-section-title', () => {
     const element = createTestComponent();
     const expectedTitle = 'Expected Title';
     element.title = expectedTitle;
+
+    await flushPromises();
+    const titleNode = element.shadowRoot.querySelector(
+      'h2.slds-text-heading_small'
+    );
+    expect(titleNode).not.toBeNull();
+    expect(titleNode.textContent).toBe(expectedTitle);
+  });
+
+  it('should display the label as the default value for the title', async () => {
+    const element = createTestComponent();
+    const expectedTitle = 'Section title';
 
     await flushPromises();
     const titleNode = element.shadowRoot.querySelector(

--- a/src/main/default/lwc/sectionTitle/sectionTitle.css
+++ b/src/main/default/lwc/sectionTitle/sectionTitle.css
@@ -1,0 +1,3 @@
+.title {
+  font-weight: bold;
+}

--- a/src/main/default/lwc/sectionTitle/sectionTitle.html
+++ b/src/main/default/lwc/sectionTitle/sectionTitle.html
@@ -1,0 +1,5 @@
+<template>
+  <h2 class="slds-text-heading_small slds-p-vertical_xx-small title">
+    {title}
+  </h2>
+</template>

--- a/src/main/default/lwc/sectionTitle/sectionTitle.js
+++ b/src/main/default/lwc/sectionTitle/sectionTitle.js
@@ -1,0 +1,19 @@
+import { LightningElement, api } from 'lwc';
+import sectionTitle from '@salesforce/label/c.cookbook_SectionTitle';
+
+/**
+ * The `sectionTitle` component is a title to mark the beginning of the case classification section.
+ * @example
+ * <c-section-title title="Explain the problem"></c-section-title>
+ */
+export default class SectionTitle extends LightningElement {
+  labels = {
+    sectionTitle
+  };
+
+  /**
+   * The section title
+   * @type {string}
+   */
+  @api title = this.labels.sectionTitle;
+}

--- a/src/main/default/lwc/sectionTitle/sectionTitle.js-meta.xml
+++ b/src/main/default/lwc/sectionTitle/sectionTitle.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/src/main/translations/fr.translation-meta.xml
+++ b/src/main/translations/fr.translation-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Translations xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customLabels>
+        <label>Titre de la section</label>
+        <name>cookbook_SectionTitle</name>
+    </customLabels>
+</Translations>


### PR DESCRIPTION
## `sectionTitle` A title to mark the beginning of different  case classification sections.

 
<img width="358" alt="SectionTitle" src="https://user-images.githubusercontent.com/86681870/142422742-d01e3339-c379-40c2-80f1-eea3b0545407.png">
