### PR TITLE
Sfint 4124 - SubjectInput component

### DIFF
--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -8,7 +8,7 @@
     <shortDescription>Section title</shortDescription>
   </labels>
   <labels>
-    <fullName>cookbook_SubjectInputLabel</fullName>
+    <fullName>cookbook_SubjectInput</fullName>
     <value>Write a descriptive title</value>
     <language>en_US</language>
     <protected>false</protected>

--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -14,4 +14,25 @@
     <protected>false</protected>
     <shortDescription>Write a descriptive title</shortDescription>
   </labels>
+  <labels>
+    <fullName>cookbook_ValueMissing</fullName>
+    <value>Complete this field</value>
+    <language>en_US</language>
+    <protected>false</protected>
+    <shortDescription>Complete this field</shortDescription>
+  </labels>
+  <labels>
+    <fullName>cookbook_ValueTooShort</fullName>
+    <value>Your entry is too short.</value>
+    <language>en_US</language>
+    <protected>false</protected>
+    <shortDescription>Your entry is too short.</shortDescription>
+  </labels>
+  <labels>
+    <fullName>cookbook_ValueTooLong</fullName>
+    <value>Your entry is too long.</value>
+    <language>en_US</language>
+    <protected>false</protected>
+    <shortDescription>Your entry is too long.</shortDescription>
+  </labels>
 </CustomLabels>

--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -8,7 +8,7 @@
     <shortDescription>Section title</shortDescription>
   </labels>
   <labels>
-    <fullName>cookbook_SubjectInput</fullName>
+    <fullName>cookbook_SubjectInputTitle</fullName>
     <value>Write a descriptive title</value>
     <language>en_US</language>
     <protected>false</protected>

--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
-    <labels>
-        <fullName>cookbook_SectionTitle</fullName>
-        <value>Section title</value>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Section title</shortDescription>
-    </labels>
+  <labels>
+    <fullName>cookbook_SectionTitle</fullName>
+    <value>Section title</value>
+    <language>en_US</language>
+    <protected>false</protected>
+    <shortDescription>Section title</shortDescription>
+  </labels>
+  <labels>
+    <fullName>cookbook_SubjectInputLabel</fullName>
+    <value>Write a descriptive title</value>
+    <language>en_US</language>
+    <protected>false</protected>
+    <shortDescription>Write a descriptive title</shortDescription>
+  </labels>
 </CustomLabels>

--- a/src/main/default/labels/CustomLabels.labels-meta.xml
+++ b/src/main/default/labels/CustomLabels.labels-meta.xml
@@ -16,23 +16,9 @@
   </labels>
   <labels>
     <fullName>cookbook_ValueMissing</fullName>
-    <value>Complete this field</value>
+    <value>Complete this field.</value>
     <language>en_US</language>
     <protected>false</protected>
     <shortDescription>Complete this field</shortDescription>
-  </labels>
-  <labels>
-    <fullName>cookbook_ValueTooShort</fullName>
-    <value>Your entry is too short.</value>
-    <language>en_US</language>
-    <protected>false</protected>
-    <shortDescription>Your entry is too short.</shortDescription>
-  </labels>
-  <labels>
-    <fullName>cookbook_ValueTooLong</fullName>
-    <value>Your entry is too long.</value>
-    <language>en_US</language>
-    <protected>false</protected>
-    <shortDescription>Your entry is too long.</shortDescription>
   </labels>
 </CustomLabels>

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -1,0 +1,91 @@
+import { createElement } from 'lwc';
+import SubjectInput from 'c/subjectInput';
+
+function createTestComponent() {
+  const element = createElement('c-subject-input', {
+    is: SubjectInput
+  });
+  document.body.appendChild(element);
+
+  return element;
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  // eslint-disable-next-line no-undef
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+jest.mock(
+  '@salesforce/label/c.cookbook_SubjectInputLabel',
+  () => ({ default: 'Write a descriptive title' }),
+  {
+    virtual: true
+  }
+);
+
+describe('c-subject-input', () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it('should display the input label', async () => {
+    const element = createTestComponent();
+    const expectedLabel = 'Expected Label';
+    element.label = expectedLabel;
+
+    await flushPromises();
+    const labelNode = element.shadowRoot.querySelector('c-section-title');
+    expect(labelNode).not.toBeNull();
+    expect(labelNode.title).toBe(expectedLabel);
+  });
+
+  it('should display the correct localized label', async () => {
+    const element = createTestComponent();
+    const expectedLabel = 'Write a descriptive title';
+
+    await flushPromises();
+    const labelNode = element.shadowRoot.querySelector('c-section-title');
+    expect(labelNode).not.toBeNull();
+    expect(labelNode.title).toBe(expectedLabel);
+  });
+  it('should display the input', async () => {
+    const element = createTestComponent();
+
+    await flushPromises();
+    const inputNode = element.shadowRoot.querySelector('input');
+    expect(inputNode).not.toBeNull();
+  });
+  it('should display the correct value in the input', async () => {
+    const element = createTestComponent();
+    const expectedValue = 'Expected Value';
+
+    await flushPromises();
+    const inputNode = element.shadowRoot.querySelector('input');
+
+    const inputEvent = new CustomEvent('input');
+    inputNode.value = expectedValue;
+    inputNode.dispatchEvent(inputEvent);
+
+    expect(element.value).toBe(expectedValue);
+  });
+  it('should respect the max lenght of the input', async () => {
+    const element = createTestComponent();
+    const longValue = 'The value should end here. and not here.';
+    const expectedValue = 'The value should end here.';
+    const maxLength = 26;
+    element.maxLength = maxLength;
+
+    await flushPromises();
+    const inputNode = element.shadowRoot.querySelector('input');
+
+    const inputEvent = new CustomEvent('input');
+    inputNode.value = longValue;
+    await inputNode.dispatchEvent(inputEvent);
+
+    expect(element.value).toBe(expectedValue);
+  });
+});

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -23,6 +23,13 @@ jest.mock(
     virtual: true
   }
 );
+jest.mock(
+  '@salesforce/label/c.cookbook_ValueMissing',
+  () => ({ default: 'Complete this field.' }),
+  {
+    virtual: true
+  }
+);
 
 describe('c-subject-input', () => {
   afterEach(() => {
@@ -88,16 +95,35 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
-  it('should show an error when the value is empty and the imput is required ', async () => {
+  it('should show an error when the value is empty and the imput is required', async () => {
     const element = createTestComponent();
     const expectedErrorMEssage = 'Expected Error Message';
     element.required = true;
     element.messageWhenValueMissing = expectedErrorMEssage;
-    element.reportValidity();
 
     await flushPromises();
+    const inputNode = element.shadowRoot.querySelector('input');
+    inputNode.value = '';
+    await element.reportValidity();
     const errorNode = element.shadowRoot.querySelector(
-      '.slds-form-element__help'
+      'div.slds-form-element__help'
+    );
+
+    expect(element.hasError).toBe(true);
+    expect(errorNode).not.toBeNull();
+    expect(errorNode.textContent).toBe(expectedErrorMEssage);
+  });
+  it('should show the default error message when the value is empty and the imput is required', async () => {
+    const element = createTestComponent();
+    const expectedErrorMEssage = 'Complete this field.';
+    element.required = true;
+
+    await flushPromises();
+    const inputNode = element.shadowRoot.querySelector('input');
+    inputNode.value = '';
+    await element.reportValidity();
+    const errorNode = element.shadowRoot.querySelector(
+      'div.slds-form-element__help'
     );
 
     expect(element.hasError).toBe(true);

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -81,6 +81,7 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
+  
   it('should respect the max length of the input', async () => {
     const element = createTestComponent();
     const maxLength = 26;

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -46,7 +46,7 @@ describe('c-subject-input', () => {
 
     await flushPromises();
     const labelNode = element.shadowRoot.querySelector('c-section-title');
-    expect(labelNode).not.toBeNull();
+    expect(labelNode).toBeDefined();
     expect(labelNode.title).toBe(expectedLabel);
   });
 

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -59,6 +59,7 @@ describe('c-subject-input', () => {
     expect(labelNode).not.toBeNull();
     expect(labelNode.title).toBe(expectedLabel);
   });
+  
   it('should display the input', async () => {
     const element = createTestComponent();
 

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -52,12 +52,11 @@ describe('c-subject-input', () => {
 
   it('should display the correct localized label', async () => {
     const element = createTestComponent();
-    const expectedLabel = 'Write a descriptive title';
 
     await flushPromises();
     const labelNode = element.shadowRoot.querySelector('c-section-title');
     expect(labelNode).not.toBeNull();
-    expect(labelNode.title).toBe(expectedLabel);
+    expect(labelNode.title).toBe('Write a descriptive title');
   });
   
   it('should display the input', async () => {

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -88,4 +88,20 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
+  it('should show an error when the value is empty and the imput is required ', async () => {
+    const element = createTestComponent();
+    const expectedErrorMEssage = 'Expected Error Message';
+    element.required = true;
+    element.messageWhenValueMissing = expectedErrorMEssage;
+    element.reportValidity();
+
+    await flushPromises();
+    const errorNode = element.shadowRoot.querySelector(
+      '.slds-form-element__help'
+    );
+
+    expect(element.hasError).toBe(true);
+    expect(errorNode).not.toBeNull();
+    expect(errorNode.textContent).toBe(expectedErrorMEssage);
+  });
 });

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -67,6 +67,7 @@ describe('c-subject-input', () => {
     const inputNode = element.shadowRoot.querySelector('input');
     expect(inputNode).not.toBeNull();
   });
+  
   it('should display the correct value in the input', async () => {
     const element = createTestComponent();
     const expectedValue = 'Expected Value';

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -74,9 +74,9 @@ describe('c-subject-input', () => {
   });
   it('should respect the max lenght of the input', async () => {
     const element = createTestComponent();
-    const longValue = 'The value should end here. and not here.';
-    const expectedValue = 'The value should end here.';
     const maxLength = 26;
+    const longValue = 'The value should end here. and not here.';
+    const expectedValue = longValue.substring(0, maxLength);
     element.maxLength = maxLength;
 
     await flushPromises();

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -11,7 +11,7 @@ function createTestComponent() {
 }
 
 // Helper function to wait until the microtask queue is empty.
-function flushPromises() {
+function allPromisesResolution() {
   // eslint-disable-next-line no-undef
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -44,7 +44,7 @@ describe('c-subject-input', () => {
     const expectedLabel = 'Expected Label';
     element.label = expectedLabel;
 
-    await flushPromises();
+    await allPromisesResolution();
     const labelNode = element.shadowRoot.querySelector('c-section-title');
     expect(labelNode).toBeDefined();
     expect(labelNode.title).toBe(expectedLabel);
@@ -53,25 +53,25 @@ describe('c-subject-input', () => {
   it('should display the correct localized label', async () => {
     const element = createTestComponent();
 
-    await flushPromises();
+    await allPromisesResolution();
     const labelNode = element.shadowRoot.querySelector('c-section-title');
     expect(labelNode).not.toBeNull();
     expect(labelNode.title).toBe('Write a descriptive title');
   });
-  
+
   it('should display the input', async () => {
     const element = createTestComponent();
 
-    await flushPromises();
+    await allPromisesResolution();
     const inputNode = element.shadowRoot.querySelector('input');
     expect(inputNode).not.toBeNull();
   });
-  
+
   it('should display the correct value in the input', async () => {
     const element = createTestComponent();
     const expectedValue = 'Expected Value';
 
-    await flushPromises();
+    await allPromisesResolution();
     const inputNode = element.shadowRoot.querySelector('input');
 
     const inputEvent = new CustomEvent('input');
@@ -80,7 +80,7 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
-  
+
   it('should respect the max length of the input', async () => {
     const element = createTestComponent();
     const maxLength = 26;
@@ -88,7 +88,7 @@ describe('c-subject-input', () => {
     const expectedValue = longValue.substring(0, maxLength);
     element.maxLength = maxLength;
 
-    await flushPromises();
+    await allPromisesResolution();
     const inputNode = element.shadowRoot.querySelector('input');
 
     const inputEvent = new CustomEvent('input');
@@ -97,14 +97,14 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
-  
+
   it('should show an error when the value is empty and the input is required', async () => {
     const element = createTestComponent();
     const expectedErrorMessage = 'Expected Error Message';
     element.required = true;
     element.messageWhenValueMissing = expectedErrorMessage;
 
-    await flushPromises();
+    await allPromisesResolution();
     const inputNode = element.shadowRoot.querySelector('input');
     inputNode.value = '';
     await element.reportValidity();
@@ -116,13 +116,13 @@ describe('c-subject-input', () => {
     expect(errorNode).not.toBeNull();
     expect(errorNode.textContent).toBe(expectedErrorMessage);
   });
-  
+
   it('should show the default localized error message when the value is empty and the input is required', async () => {
     const element = createTestComponent();
     const expectedErrorMessage = 'Complete this field.';
     element.required = true;
 
-    await flushPromises();
+    await allPromisesResolution();
     const inputNode = element.shadowRoot.querySelector('input');
     inputNode.value = '';
     await element.reportValidity();

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -96,6 +96,7 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
+  
   it('should show an error when the value is empty and the input is required', async () => {
     const element = createTestComponent();
     const expectedErrorMessage = 'Expected Error Message';

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -117,6 +117,7 @@ describe('c-subject-input', () => {
     expect(errorNode).not.toBeNull();
     expect(errorNode.textContent).toBe(expectedErrorMessage);
   });
+  
   it('should show the default localized error message when the value is empty and the input is required', async () => {
     const element = createTestComponent();
     const expectedErrorMessage = 'Complete this field.';

--- a/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
+++ b/src/main/default/lwc/subjectInput/__test__/subjectInput.test.js
@@ -17,7 +17,7 @@ function flushPromises() {
 }
 
 jest.mock(
-  '@salesforce/label/c.cookbook_SubjectInputLabel',
+  '@salesforce/label/c.cookbook_SubjectInputTitle',
   () => ({ default: 'Write a descriptive title' }),
   {
     virtual: true
@@ -79,7 +79,7 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
-  it('should respect the max lenght of the input', async () => {
+  it('should respect the max length of the input', async () => {
     const element = createTestComponent();
     const maxLength = 26;
     const longValue = 'The value should end here. and not here.';
@@ -95,11 +95,11 @@ describe('c-subject-input', () => {
 
     expect(element.value).toBe(expectedValue);
   });
-  it('should show an error when the value is empty and the imput is required', async () => {
+  it('should show an error when the value is empty and the input is required', async () => {
     const element = createTestComponent();
-    const expectedErrorMEssage = 'Expected Error Message';
+    const expectedErrorMessage = 'Expected Error Message';
     element.required = true;
-    element.messageWhenValueMissing = expectedErrorMEssage;
+    element.messageWhenValueMissing = expectedErrorMessage;
 
     await flushPromises();
     const inputNode = element.shadowRoot.querySelector('input');
@@ -111,11 +111,11 @@ describe('c-subject-input', () => {
 
     expect(element.hasError).toBe(true);
     expect(errorNode).not.toBeNull();
-    expect(errorNode.textContent).toBe(expectedErrorMEssage);
+    expect(errorNode.textContent).toBe(expectedErrorMessage);
   });
-  it('should show the default error message when the value is empty and the imput is required', async () => {
+  it('should show the default localized error message when the value is empty and the input is required', async () => {
     const element = createTestComponent();
-    const expectedErrorMEssage = 'Complete this field.';
+    const expectedErrorMessage = 'Complete this field.';
     element.required = true;
 
     await flushPromises();
@@ -128,6 +128,6 @@ describe('c-subject-input', () => {
 
     expect(element.hasError).toBe(true);
     expect(errorNode).not.toBeNull();
-    expect(errorNode.textContent).toBe(expectedErrorMEssage);
+    expect(errorNode.textContent).toBe(expectedErrorMessage);
   });
 });

--- a/src/main/default/lwc/subjectInput/subjectInput.css
+++ b/src/main/default/lwc/subjectInput/subjectInput.css
@@ -6,6 +6,7 @@
   justify-content: flex-end;
   font-weight: 200;
 }
+
 .slds-input {
   padding-right: 4.25rem;
   height: 2.5rem;

--- a/src/main/default/lwc/subjectInput/subjectInput.css
+++ b/src/main/default/lwc/subjectInput/subjectInput.css
@@ -1,0 +1,14 @@
+.input_count {
+  top: 0;
+  right: 0.75rem;
+  width: 3.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-weight: 200;
+}
+.slds-input {
+  padding-right: 4.25rem;
+  height: 2.5rem;
+}

--- a/src/main/default/lwc/subjectInput/subjectInput.css
+++ b/src/main/default/lwc/subjectInput/subjectInput.css
@@ -2,9 +2,7 @@
   top: 0;
   right: 0.75rem;
   width: 3.5rem;
-  height: 100%;
-  display: flex;
-  align-items: center;
+  height: 2.5rem;
   justify-content: flex-end;
   font-weight: 200;
 }

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -9,7 +9,7 @@
           class="slds-input"
           oninput={handleChange}
           maxlength={maxLength}
-          minlength="10"
+          minlength={minLength}
           required={required}
         />
         <template if:true={hasError}>

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -11,7 +11,6 @@
           class="slds-input"
           oninput={handleChange}
           maxlength={maxLength}
-          minlength={minLength}
           required={required}
           id="subject-input"
           aria-describedby="subject-error-message"

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -1,7 +1,7 @@
 <template>
   <c-section-title title={label}></c-section-title>
   <div class="slds-is-relative">
-    <div class="slds-form-element">
+    <div class={formClass}>
       <div class="slds-form-element__control">
         <input
           value={value}
@@ -9,9 +9,18 @@
           class="slds-input"
           oninput={handleChange}
           maxlength={maxLength}
+          minlength="10"
+          required={required}
         />
+        <template if:true={hasError}>
+          <div class="slds-form-element__help" id="error-message-id-49">
+            {errorMessage}
+          </div>
+        </template>
       </div>
     </div>
-    <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
+    <span class="slds-is-absolute input_count slds-align_absolute-center"
+      >{length}/{maxLength}</span
+    >
   </div>
 </template>

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -4,23 +4,21 @@
   </label>
   <div class="slds-is-relative">
     <div class={formClass}>
-      <div class="slds-form-element__control">
-        <input
-          value={value}
-          type="text"
-          class="slds-input"
-          oninput={handleChange}
-          maxlength={maxLength}
-          required={required}
-          id="subject-input"
-          aria-describedby="subject-error-message"
-        />
-        <template if:true={hasError}>
-          <div class="slds-form-element__help" id="subject-error-message">
-            {errorMessage}
-          </div>
-        </template>
-      </div>
+      <input
+        value={value}
+        type="text"
+        class="slds-input"
+        oninput={handleChange}
+        maxlength={maxLength}
+        required={required}
+        id="subject-input"
+        aria-describedby="subject-error-message"
+      />
+      <template if:true={hasError}>
+        <div class="slds-form-element__help" id="subject-error-message">
+          {errorMessage}
+        </div>
+      </template>
     </div>
     <span class="slds-is-absolute input_count slds-align_absolute-center"
       >{length}/{maxLength}</span

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -1,5 +1,7 @@
 <template>
-  <c-section-title title={label}></c-section-title>
+  <label for="subject-input">
+    <c-section-title title={label}></c-section-title>
+  </label>
   <div class="slds-is-relative">
     <div class={formClass}>
       <div class="slds-form-element__control">
@@ -11,9 +13,11 @@
           maxlength={maxLength}
           minlength={minLength}
           required={required}
+          id="subject-input"
+          aria-describedby="subject-error-message"
         />
         <template if:true={hasError}>
-          <div class="slds-form-element__help" id="error-message-id-49">
+          <div class="slds-form-element__help" id="subject-error-message">
             {errorMessage}
           </div>
         </template>

--- a/src/main/default/lwc/subjectInput/subjectInput.html
+++ b/src/main/default/lwc/subjectInput/subjectInput.html
@@ -1,0 +1,17 @@
+<template>
+  <c-section-title title={label}></c-section-title>
+  <div class="slds-is-relative">
+    <div class="slds-form-element">
+      <div class="slds-form-element__control">
+        <input
+          value={value}
+          type="text"
+          class="slds-input"
+          oninput={handleChange}
+          maxlength={maxLength}
+        />
+      </div>
+    </div>
+    <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
+  </div>
+</template>

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -26,10 +26,62 @@ export default class SubjectInput extends LightningElement {
    */
   @api maxLength = 100;
 
+  /**
+   * The minimum length of the string to be written in the input.
+   * @api
+   * @type {number}
+   * @defaultValue `0`
+   */
+  @api minLength = 10;
+
+  /**
+   * Tells if the input is required.
+   * @api
+   * @type {boolean}
+   * @defaultValue `false`
+   */
+  @api required = false;
+
+  /**
+   * The error message to show when the value is missing.
+   * @api
+   * @type {string}
+   * @defaultValue `false`
+   */
+  @api messageWhenValueMissing = 'empty';
+
+  /**
+   * The error message to show when the value is too short.
+   * @api
+   * @type {string}
+   * @defaultValue `''`
+   */
+  @api messageWhenTooShort = 'too short';
+
+  /**
+   * The error message to show when the value is too long.
+   * @api
+   * @type {string}
+   * @defaultValue `''`
+   */
+  @api messageWhenTooLong = 'too long';
+
   /** @type {string} */
   _value = '';
 
+  /** @type {string} */
+  _errorMessage = '';
+
+  /** @type {boolean} */
+  _hasError = false;
+
+  /**
+   * Handles the changes in the input.
+   * @return {void}
+   */
   handleChange = (e) => {
+    this._hasError = false;
+    this._errorMessage = '';
     if (e.target.value.length <= this.maxLength) {
       this._value = e.target.value;
     } else {
@@ -52,5 +104,61 @@ export default class SubjectInput extends LightningElement {
    */
   get length() {
     return this._value.length;
+  }
+
+  /**
+   * Tells if the value of the input is valid.
+   * @api
+   * @type {boolean}
+   */
+  @api get valid() {
+    const input = this.template.querySelector('input');
+    return input.validity.valid;
+  }
+
+  /**
+   * Returns the error message to be shown.
+   * @type {string}
+   */
+  get errorMessage() {
+    return this._errorMessage;
+  }
+
+  /**
+   * Returns the CSS class of the form.
+   * @returns {string}
+   */
+  get formClass() {
+    return this._hasError
+      ? 'slds-form-element slds-has-error'
+      : 'slds-form-element';
+  }
+
+  /**
+   * Tells if thers is an error in the input.
+   * @returns {boolean}
+   */
+  @api get hasError() {
+    return this._hasError;
+  }
+
+  /**
+   * @api
+   * Shows error messages in the componets if there is some.
+   * @returns {void}
+   */
+  @api reportValidity() {
+    const input = this.template.querySelector('input');
+    const { valid, valueMissing, tooShort, tooLong } = input.validity;
+    if (!valid) {
+      this._hasError = true;
+      if (valueMissing) {
+        this._errorMessage = this.messageWhenValueMissing;
+      } else if (tooShort) {
+        this._errorMessage = this.messageWhenTooShort;
+      } else if (tooLong) {
+        this._errorMessage = this.messageWhenTooLong;
+      }
+    }
   }
 }

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -82,17 +82,6 @@ export default class SubjectInput extends LightningElement {
   get length() {
     return this._value.length;
   }
-
-  /**
-   * Tells if the value of the input is valid.
-   * @api
-   * @type {boolean}
-   */
-  @api get valid() {
-    const input = this.template.querySelector('input');
-    return input.validity.valid;
-  }
-
   /**
    * Returns the error message to be shown.
    * @type {string}

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -5,7 +5,7 @@ import errorValueMissing from '@salesforce/label/c.cookbook_ValueMissing';
 /**
  * The `SubjectInput` component  displays a text input for the case subject.
  * @example
- * <c-subject-input label="Write a descriptive title" maxLength="50" message-when-value-missing="Complete this field."></c-subject-input>
+ * <c-subject-input label="Write a descriptive title" maxLength="50" message-when-value-missing="Complete this field." required></c-subject-input>
  */
 export default class SubjectInput extends LightningElement {
   labels = {
@@ -37,12 +37,12 @@ export default class SubjectInput extends LightningElement {
   @api required = false;
 
   /**
-   * The error message to show when the value is missing.
+   * The error message to be shown when the value is missing.
    * @api
    * @type {string}
    * @defaultValue `'Complete this field.`
    */
-  @api messageWhenValueMissing = errorValueMissing;
+  @api messageWhenValueMissing = this.labels.errorValueMissing;
 
   /** @type {string} */
   _value = '';
@@ -60,11 +60,10 @@ export default class SubjectInput extends LightningElement {
   handleChange = (e) => {
     this._hasError = false;
     this._errorMessage = '';
-    if (e.target.value.length <= this.maxLength) {
-      this._value = e.target.value;
-    } else {
-      this._value = e.target.value.substring(0, this.maxLength);
-    }
+    this._value =
+      e.target.value.length <= this.maxLength
+        ? e.target.value
+        : e.target.value.substring(0, this.maxLength);
   };
 
   /**
@@ -113,7 +112,7 @@ export default class SubjectInput extends LightningElement {
   }
 
   /**
-   * Tells if ther is an error in the input.
+   * Tells if there is an error in the input.
    * @returns {boolean}
    */
   @api get hasError() {
@@ -122,7 +121,7 @@ export default class SubjectInput extends LightningElement {
 
   /**
    * @api
-   * Shows an error message in the componets if there an error.
+   * Shows an error message in the componet if there is an error.
    * @returns {void}
    */
   @api reportValidity() {

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -1,5 +1,5 @@
 import { LightningElement, api } from 'lwc';
-import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInput';
+import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputTitle';
 import errorValueMissing from '@salesforce/label/c.cookbook_ValueMissing';
 
 /**

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -1,0 +1,56 @@
+import { LightningElement, api } from 'lwc';
+import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputLabel';
+
+/**
+ * The `SubjectInput` component  displays a text input for the case subject.
+ * @example
+ * <c-subject-input label="Write a descriptive title" maxLength="50" ></c-subject-input>
+ */
+export default class SubjectInput extends LightningElement {
+  labels = {
+    writeDescriptiveTitle
+  };
+  /**
+   * The label of the input.
+   * @api
+   * @type {string}
+   * @defaultValue `'Write a descriptive title'`
+   */
+  @api label = this.labels.writeDescriptiveTitle;
+
+  /**
+   * The maximum length of the string to be written in the input.
+   * @api
+   * @type {number}
+   * @defaultValue `100`
+   */
+  @api maxLength = 100;
+
+  /** @type {string} */
+  _value = '';
+
+  handleChange = (e) => {
+    if (e.target.value.length <= this.maxLength) {
+      this._value = e.target.value;
+    } else {
+      this._value = e.target.value.substring(0, this.maxLength);
+    }
+  };
+
+  /**
+   * Returns the value of the input.
+   * @api
+   * @returns {string}
+   */
+  @api get value() {
+    return this._value;
+  }
+
+  /**
+   * Returns the length of the value of the input.
+   * @returns {number}
+   */
+  get length() {
+    return this._value.length;
+  }
+}

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -14,7 +14,6 @@ export default class SubjectInput extends LightningElement {
   };
   /**
    * The label of the input.
-   * @api
    * @type {string}
    * @defaultValue `'Write a descriptive title'`
    */
@@ -22,7 +21,6 @@ export default class SubjectInput extends LightningElement {
 
   /**
    * The maximum length of the string to be written in the input.
-   * @api
    * @type {number}
    * @defaultValue `100`
    */
@@ -30,7 +28,6 @@ export default class SubjectInput extends LightningElement {
 
   /**
    * Tells if the input is required.
-   * @api
    * @type {boolean}
    * @defaultValue `false`
    */
@@ -38,7 +35,6 @@ export default class SubjectInput extends LightningElement {
 
   /**
    * The error message to be shown when the value is missing.
-   * @api
    * @type {string}
    * @defaultValue `'Complete this field.`
    */
@@ -50,15 +46,11 @@ export default class SubjectInput extends LightningElement {
   /** @type {string} */
   _errorMessage = '';
 
-  /** @type {boolean} */
-  _hasError = false;
-
   /**
    * Handles the changes in the input.
    * @return {void}
    */
   handleChange = (e) => {
-    this._hasError = false;
     this._errorMessage = '';
     this._value =
       e.target.value.length <= this.maxLength
@@ -95,7 +87,7 @@ export default class SubjectInput extends LightningElement {
    * @returns {string}
    */
   get formClass() {
-    return this._hasError
+    return this.hasError
       ? 'slds-form-element slds-has-error'
       : 'slds-form-element';
   }
@@ -105,18 +97,16 @@ export default class SubjectInput extends LightningElement {
    * @returns {boolean}
    */
   @api get hasError() {
-    return this._hasError;
+    return !!this._errorMessage.length;
   }
 
   /**
-   * @api
    * Shows an error message in the componet if there is an error.
    * @returns {void}
    */
   @api reportValidity() {
     const input = this.template.querySelector('input');
     if (input.validity.valueMissing) {
-      this._hasError = true;
       this._errorMessage = this.messageWhenValueMissing;
     }
   }

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -1,5 +1,8 @@
 import { LightningElement, api } from 'lwc';
 import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputLabel';
+import errorValueMissing from '@salesforce/label/c.cookbook_ValueMissing';
+import valueTooShort from '@salesforce/label/c.cookbook_ValueTooShort';
+import valueTooLong from '@salesforce/label/c.cookbook_ValueTooLong';
 
 /**
  * The `SubjectInput` component  displays a text input for the case subject.
@@ -8,7 +11,10 @@ import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputLabe
  */
 export default class SubjectInput extends LightningElement {
   labels = {
-    writeDescriptiveTitle
+    writeDescriptiveTitle,
+    errorValueMissing,
+    valueTooLong,
+    valueTooShort
   };
   /**
    * The label of the input.
@@ -46,25 +52,25 @@ export default class SubjectInput extends LightningElement {
    * The error message to show when the value is missing.
    * @api
    * @type {string}
-   * @defaultValue `false`
+   * @defaultValue `'Complete this field.`
    */
-  @api messageWhenValueMissing = 'empty';
+  @api messageWhenValueMissing = errorValueMissing;
 
   /**
    * The error message to show when the value is too short.
    * @api
    * @type {string}
-   * @defaultValue `''`
+   * @defaultValue `'Your entry is too short.'`
    */
-  @api messageWhenTooShort = 'too short';
+  @api messageWhenTooShort = valueTooShort;
 
   /**
    * The error message to show when the value is too long.
    * @api
    * @type {string}
-   * @defaultValue `''`
+   * @defaultValue `'Your entry is too long.'`
    */
-  @api messageWhenTooLong = 'too long';
+  @api messageWhenTooLong = valueTooLong;
 
   /** @type {string} */
   _value = '';

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -74,6 +74,7 @@ export default class SubjectInput extends LightningElement {
   get length() {
     return this._value.length;
   }
+
   /**
    * Returns the error message to be shown.
    * @type {string}
@@ -87,9 +88,7 @@ export default class SubjectInput extends LightningElement {
    * @returns {string}
    */
   get formClass() {
-    return this.hasError
-      ? 'slds-form-element slds-has-error'
-      : 'slds-form-element';
+    return `slds-form-element ${this.hasError ? 'slds-has-error' : ''}`;
   }
 
   /**

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -1,8 +1,6 @@
 import { LightningElement, api } from 'lwc';
 import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputLabel';
 import errorValueMissing from '@salesforce/label/c.cookbook_ValueMissing';
-import valueTooShort from '@salesforce/label/c.cookbook_ValueTooShort';
-import valueTooLong from '@salesforce/label/c.cookbook_ValueTooLong';
 
 /**
  * The `SubjectInput` component  displays a text input for the case subject.
@@ -12,9 +10,7 @@ import valueTooLong from '@salesforce/label/c.cookbook_ValueTooLong';
 export default class SubjectInput extends LightningElement {
   labels = {
     writeDescriptiveTitle,
-    errorValueMissing,
-    valueTooLong,
-    valueTooShort
+    errorValueMissing
   };
   /**
    * The label of the input.
@@ -33,14 +29,6 @@ export default class SubjectInput extends LightningElement {
   @api maxLength = 100;
 
   /**
-   * The minimum length of the string to be written in the input.
-   * @api
-   * @type {number}
-   * @defaultValue `0`
-   */
-  @api minLength = 10;
-
-  /**
    * Tells if the input is required.
    * @api
    * @type {boolean}
@@ -55,22 +43,6 @@ export default class SubjectInput extends LightningElement {
    * @defaultValue `'Complete this field.`
    */
   @api messageWhenValueMissing = errorValueMissing;
-
-  /**
-   * The error message to show when the value is too short.
-   * @api
-   * @type {string}
-   * @defaultValue `'Your entry is too short.'`
-   */
-  @api messageWhenTooShort = valueTooShort;
-
-  /**
-   * The error message to show when the value is too long.
-   * @api
-   * @type {string}
-   * @defaultValue `'Your entry is too long.'`
-   */
-  @api messageWhenTooLong = valueTooLong;
 
   /** @type {string} */
   _value = '';
@@ -141,7 +113,7 @@ export default class SubjectInput extends LightningElement {
   }
 
   /**
-   * Tells if thers is an error in the input.
+   * Tells if ther is an error in the input.
    * @returns {boolean}
    */
   @api get hasError() {
@@ -150,21 +122,14 @@ export default class SubjectInput extends LightningElement {
 
   /**
    * @api
-   * Shows error messages in the componets if there is some.
+   * Shows an error message in the componets if there an error.
    * @returns {void}
    */
   @api reportValidity() {
     const input = this.template.querySelector('input');
-    const { valid, valueMissing, tooShort, tooLong } = input.validity;
-    if (!valid) {
+    if (input.validity.valueMissing) {
       this._hasError = true;
-      if (valueMissing) {
-        this._errorMessage = this.messageWhenValueMissing;
-      } else if (tooShort) {
-        this._errorMessage = this.messageWhenTooShort;
-      } else if (tooLong) {
-        this._errorMessage = this.messageWhenTooLong;
-      }
+      this._errorMessage = this.messageWhenValueMissing;
     }
   }
 }

--- a/src/main/default/lwc/subjectInput/subjectInput.js
+++ b/src/main/default/lwc/subjectInput/subjectInput.js
@@ -1,11 +1,11 @@
 import { LightningElement, api } from 'lwc';
-import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInputLabel';
+import writeDescriptiveTitle from '@salesforce/label/c.cookbook_SubjectInput';
 import errorValueMissing from '@salesforce/label/c.cookbook_ValueMissing';
 
 /**
  * The `SubjectInput` component  displays a text input for the case subject.
  * @example
- * <c-subject-input label="Write a descriptive title" maxLength="50" ></c-subject-input>
+ * <c-subject-input label="Write a descriptive title" maxLength="50" message-when-value-missing="Complete this field."></c-subject-input>
  */
 export default class SubjectInput extends LightningElement {
   labels = {

--- a/src/main/default/lwc/subjectInput/subjectInput.js-meta.xml
+++ b/src/main/default/lwc/subjectInput/subjectInput.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/src/main/translations/fr.translation-meta.xml
+++ b/src/main/translations/fr.translation-meta.xml
@@ -6,6 +6,10 @@
   </customLabels>
   <customLabels>
     <label>Écrivez un titre descriptif</label>
-    <name>cookbook_SubjectInputLabel</name>
+    <name>cookbook_SubjectInput</name>
+  </customLabels>
+  <customLabels>
+    <label>Remplissez ce champ.</label>
+    <name>cookbook_ValueMissing</name>
   </customLabels>
 </Translations>

--- a/src/main/translations/fr.translation-meta.xml
+++ b/src/main/translations/fr.translation-meta.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Translations xmlns="http://soap.sforce.com/2006/04/metadata">
-    <customLabels>
-        <label>Titre de la section</label>
-        <name>cookbook_SectionTitle</name>
-    </customLabels>
+  <customLabels>
+    <label>Titre de la section</label>
+    <name>cookbook_SectionTitle</name>
+  </customLabels>
+  <customLabels>
+    <label>Écrivez un titre descriptif</label>
+    <name>cookbook_SubjectInputLabel</name>
+  </customLabels>
 </Translations>

--- a/src/main/translations/fr.translation-meta.xml
+++ b/src/main/translations/fr.translation-meta.xml
@@ -6,7 +6,7 @@
   </customLabels>
   <customLabels>
     <label>Écrivez un titre descriptif</label>
-    <name>cookbook_SubjectInput</name>
+    <name>cookbook_SubjectInputTitle</name>
   </customLabels>
   <customLabels>
     <label>Remplissez ce champ.</label>


### PR DESCRIPTION
## Link to design : [Case-Assist-User-Experience](https://www.figma.com/file/mGZNYe9DbqIL1NO4m292PG/Case-Assist-User-experience?node-id=348%3A29462)

## subjectInput component
<img width="975" alt="subjectInput" src="https://user-images.githubusercontent.com/86681870/143308508-dccb1510-4c4b-4ddf-9361-08785adb39e0.png">

### Demonstration of how the subjectInput will behave when the required property is set to true and the input is left  empty

https://user-images.githubusercontent.com/86681870/143309014-d24cd476-1448-44f5-afe4-6c8d9662af42.mov


