### PR TITLE
DEM-1164 unused search-engine-id attribute removed

### DIFF
--- a/src/main/default/lwc/reviewResourcesScreen/reviewResourcesScreen.html
+++ b/src/main/default/lwc/reviewResourcesScreen/reviewResourcesScreen.html
@@ -26,11 +26,7 @@
         ></c-main-title>
       </div>
       <div class="slds-var-p-top_medium slds-var-m-top_xx-large">
-        <c-quantic-document-suggestion
-          engine-id={engineId}
-          search-engine-id="search"
-          show-quickview
-        >
+        <c-quantic-document-suggestion engine-id={engineId} show-quickview>
           <c-vote-count-wrapper slot="rating"></c-vote-count-wrapper>
           <c-vote-tracker-wrapper
             engine-id={engineId}


### PR DESCRIPTION
[DEM-1164](https://coveord.atlassian.net/browse/DEM-1164)

The seach-engine-id attribute was removed from the api of the QuanticDocumentSuggestion and was forgotten inside the reviewReosurces screen in the cookbook.