### PR TITLE
fix(DEM-1196): fix broken link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm run build
 
 The Org Development Model allows you to connect directly to a non-source-tracked org (sandbox, Developer Edition (DE) org, Trailhead Playground, or even a production org) to retrieve and deploy code directly. This model is similar to the type of development you have done in the past using tools such as Force.com IDE or MavensMate.
 
-To start developing with this model in Visual Studio Code, see [Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.  
+To start developing with this model in Visual Studio Code, see [Visual Studio Code for Salesforce Development](https://trailhead.salesforce.com/content/learn/projects/quickstart-vscode-salesforce/use-vscode-for-salesforce). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.  
 
 Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:  
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm run build
 
 The Org Development Model allows you to connect directly to a non-source-tracked org (sandbox, Developer Edition (DE) org, Trailhead Playground, or even a production org) to retrieve and deploy code directly. This model is similar to the type of development you have done in the past using tools such as Force.com IDE or MavensMate.
 
-To start developing with this model in Visual Studio Code, see [Visual Studio Code for Salesforce Development](https://trailhead.salesforce.com/content/learn/projects/quickstart-vscode-salesforce/use-vscode-for-salesforce). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.  
+To start developing with this model in Visual Studio Code, see [Visual Studio Code for Salesforce Development](https://trailhead.salesforce.com/content/learn/projects/quickstart-vscode-salesforce/use-vscode-for-salesforce). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/projects/quickstart-vscode-salesforce) Trailhead module.  
 
 Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:  
 ```


### PR DESCRIPTION
[Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model)  replaced by [Visual Studio Code for Salesforce Development](https://trailhead.salesforce.com/content/learn/projects/quickstart-vscode-salesforce).