### PR TITLE
SFINT-4958: new version created

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,24 +75,30 @@ npm run build
 
 The Org Development Model allows you to connect directly to a non-source-tracked org (sandbox, Developer Edition (DE) org, Trailhead Playground, or even a production org) to retrieve and deploy code directly. This model is similar to the type of development you have done in the past using tools such as Force.com IDE or MavensMate.
 
-To start developing with this model in Visual Studio Code, see [Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.  
+To start developing with this model in Visual Studio Code, see [Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.
 
-Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:  
+Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:
+
 ```
 sfdx force:source:deploy
 ```
 
 ### 3b. Push the Code in a Scratch Org
-Use the command `SFDX: Push Source to Org` in VS Code or type the following SFDX command in your CLI:  
+
+Use the command `SFDX: Push Source to Org` in VS Code or type the following SFDX command in your CLI:
+
 ```
 sfdx force:source:push
 ```
 
 ### 3c. Installing the App Using an Unlocked Package
-Type the following SFDX command in your CLI:  
+
+Type the following SFDX command in your CLI:
+
 ```
-sfdx force:package:install --package 04t3s000003anxdAAA -u <USER_NAME>
+sfdx force:package:install --package 04t3s000003T1s3AAC -u <USER_NAME>
 ```
+
 Where you replace <USER_NAME> by your username in the target organization.
 
 ### 4. Enable the Case Flow in Your Community

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npm run build
 The Org Development Model allows you to connect directly to a non-source-tracked org (sandbox, Developer Edition (DE) org, Trailhead Playground, or even a production org) to retrieve and deploy code directly. This model is similar to the type of development you have done in the past using tools such as Force.com IDE or MavensMate.
 
 To start developing with this model in Visual Studio Code, see [Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.
+
 Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:
 
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Type the following SFDX command in your CLI:
 ```
 sfdx force:package:install --package 04t3s000003T1s3AAC -u <USER_NAME>
 ```
-
 Where you replace <USER_NAME> by your username in the target organization.
 
 ### 4. Enable the Case Flow in Your Community

--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ sfdx force:source:deploy
 ```
 
 ### 3b. Push the Code in a Scratch Org
-
 Use the command `SFDX: Push Source to Org` in VS Code or type the following SFDX command in your CLI:
-
 ```
 sfdx force:source:push
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ npm run build
 The Org Development Model allows you to connect directly to a non-source-tracked org (sandbox, Developer Edition (DE) org, Trailhead Playground, or even a production org) to retrieve and deploy code directly. This model is similar to the type of development you have done in the past using tools such as Force.com IDE or MavensMate.
 
 To start developing with this model in Visual Studio Code, see [Org Development Model with VS Code](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/org-development-model). For details about the model, see the [Org Development Model](https://trailhead.salesforce.com/content/learn/modules/org-development-model) Trailhead module.
-
 Use the command `SFDX: Deploy Source to Org` in VS Code or type the following SFDX command in your CLI:
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ sfdx force:source:push
 ```
 
 ### 3c. Installing the App Using an Unlocked Package
-
 Type the following SFDX command in your CLI:
-
 ```
 sfdx force:package:install --package 04t3s000003T1s3AAC -u <USER_NAME>
 ```

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,12 +7,12 @@
     {
       "path": "src/main/default",
       "package": "Salesforce Quantic Case Assist Cookbook",
-      "versionName": "Version 1.0.4",
+      "versionName": "Version 1.0.6",
       "versionNumber": "1.0.0.NEXT",
       "default": false,
       "dependencies": [
         {
-          "package": "Quantic@1.13.0-1"
+          "package": "Quantic v2.17.3.0"
         }
       ]
     }
@@ -21,7 +21,7 @@
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "52.0",
   "packageAliases": {
-    "Quantic@1.13.0-1": "04t6g000008fgbJAAQ",
-    "Salesforce Quantic Case Assist Cookbook": "04t3s000003KpUmAAK"
+    "Quantic v2.17.3.0": "04t6g000008Sn66AAC",
+    "Salesforce Quantic Case Assist Cookbook": "0Ho3s0000008OM7CAM"
   }
 }


### PR DESCRIPTION
[SFINT-4958](https://coveord.atlassian.net/browse/SFINT-4958)

New version of the Salesforce Quantic Case Assist Cookbook package created:  `04t3s000003T1s3AAC`.
This new version uses the latest version of Quantic: `v2.17.3.0`



[SFINT-4958]: https://coveord.atlassian.net/browse/SFINT-4958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ