### PR TITLE
feat(SFINT-4959): Added apex tests for RatingsHandler class coverage

### DIFF
--- a/src/main/default/classes/RatingsHandlerTest.cls
+++ b/src/main/default/classes/RatingsHandlerTest.cls
@@ -1,0 +1,23 @@
+@isTest
+private class RatingsHandlerTest {
+  @isTest
+  static void testGetRatingWithExistingRecord() {
+    Rating__c testRating = new Rating__c(
+      Score__c = 90,
+      Document_id__c = 'TestDocumentId'
+    );
+    insert testRating;
+
+    Rating__c result = RatingsHandler.getRating('TestDocumentId');
+
+    System.assertEquals(testRating.Id, result.Id, 'The Result Id received: ' + result.Id + ' was expected to be: ' + testRating.Id);
+    System.assertEquals(testRating.Score__c, result.Score__c, 'The Result score received: ' + result.Score__c + ' was expected to be: 90');
+    System.assertEquals(testRating.Document_id__c, result.Document_id__c, 'The Result document Id received: ' + result.Document_id__c + ' was expected to be: TestDocumentId');
+  }
+
+  @isTest
+  static void testGetRatingWithNoRecord() {
+    Rating__c testRating = RatingsHandler.getRating('NonExistentDocumentId');
+    System.assertEquals(null, testRating, 'Test Rating received: ' + testRating + ' was expected to be null.');
+  }
+}

--- a/src/main/default/classes/RatingsHandlerTest.cls
+++ b/src/main/default/classes/RatingsHandlerTest.cls
@@ -11,8 +11,8 @@ private class RatingsHandlerTest {
     Rating__c result = RatingsHandler.getRating('TestDocumentId');
 
     System.assertEquals(testRating.Id, result.Id, 'The Result Id received: ' + result.Id + ' was expected to be: ' + testRating.Id);
-    System.assertEquals(testRating.Score__c, result.Score__c, 'The Result score received: ' + result.Score__c + ' was expected to be: 90');
-    System.assertEquals(testRating.Document_id__c, result.Document_id__c, 'The Result document Id received: ' + result.Document_id__c + ' was expected to be: TestDocumentId');
+    System.assertEquals(testRating.Score__c, result.Score__c, 'The Result score received: ' + result.Score__c + ' was expected to be: ' + testRating.Score__c);
+    System.assertEquals(testRating.Document_id__c, result.Document_id__c, 'The Result document Id received: ' + result.Document_id__c + ' was expected to be: ' + testRating.Document_id__c);
   }
 
   @isTest

--- a/src/main/default/classes/RatingsHandlerTest.cls-meta.xml
+++ b/src/main/default/classes/RatingsHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>52.0</apiVersion>
+  <status>Active</status>
+</ApexClass>

--- a/src/main/translations/fr.translation-meta.xml
+++ b/src/main/translations/fr.translation-meta.xml
@@ -97,10 +97,6 @@
     <name>cookbook_CreateCase</name>
   </customLabels>
   <customLabels>
-    <label>Connexion</label>
-    <name>cookbook_LogIn</name>
-  </customLabels>
-  <customLabels>
     <label>Décrire le problème</label>
     <name>cookbook_DescribeProblem</name>
   </customLabels>
@@ -123,38 +119,6 @@
   <customLabels>
     <label>Confirmer</label>
     <name>cookbook_Confirm</name>
-  </customLabels>
-  <customLabels>
-    <label>Mot de passe</label>
-    <name>cookbook_Password</name>
-  </customLabels>
-  <customLabels>
-    <label>Nom d'utilisateur</label>
-    <name>cookbook_Username</name>
-  </customLabels>
-  <customLabels>
-    <label>Se souvenir de moi</label>
-    <name>cookbook_RememberMe</name>
-  </customLabels>
-  <customLabels>
-    <label>Mot de passe oublié</label>
-    <name>cookbook_ForgetYourPassword</name>
-  </customLabels>
-  <customLabels>
-    <label>Obtenez de l'aide en 4 étapes faciles</label>
-    <name>cookbook_GetHelpRecommended</name>
-  </customLabels>
-  <customLabels>
-    <label>Obtenez de l'aide en 3 étapes faciles</label>
-    <name>cookbook_GetHelpDemo</name>
-  </customLabels>
-  <customLabels>
-    <label>Connectez-vous pour contacter un agent d'assistance</label>
-    <name>cookbook_LoginTitle</name>
-  </customLabels>
-  <customLabels>
-    <label>Nous serons en mesure de vous proposer de meilleures solutions sur la base des informations relatives à votre compte.</label>
-    <name>cookbook_LoginSubtitle</name>
   </customLabels>
   <customLabels>
     <label>Précédent</label>


### PR DESCRIPTION
[SFINT-4959](https://coveord.atlassian.net/browse/SFINT-4959)

In order to be able to promote the package on the app exchange, we needed to make sure the apex test code coverage reached the 75% threshold.

**IN THIS PR:**
- Added Apex test to reach the 75% threshold of coverage for the package. Class now went from 0 to 100% coverage.
- Also removed deprecated labels translations (fr) that were no longer used since we removed some labels following the removal of the login screen to the flow. This was causing friction when trying to deploy to an org.

TESTS PASSING:
<img width="529" alt="image" src="https://github.com/coveooss/sf-case-assist-cookbook/assets/73316533/2eecfe79-f9a8-49d3-afbf-1c7bc0c5e6ed">

TEST CODE COVERAGE:

<img width="359" alt="image" src="https://github.com/coveooss/sf-case-assist-cookbook/assets/73316533/43ff4142-c257-4a3d-8137-b1df1281f01b">

<img width="747" alt="image" src="https://github.com/coveooss/sf-case-assist-cookbook/assets/73316533/64424e7c-6fd1-4e90-b71b-d4c9893bad1d">


[SFINT-4959]: https://coveord.atlassian.net/browse/SFINT-4959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ