### PR TITLE
fix(SFINT-5981): removed default value for searchHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ Where you replace <USER_NAME> by your username in the target organization.
 ### 4. Enable the Case Flow in Your Community
 
 1. In your Salesforce community, drag the Lightning Flow component in a Community page, and then select the `Case_Assist_Recommended_Flow` or the `Case_Assist_Demo_Flow` shipped with this repository.
-2. After selecting the name of the flow, you must fill the `caseAssistId` and `engineId` fields.
+2. After selecting the name of the flow, you must fill the `caseAssistId`, the `engineId` and the `searchHub` fields.
    1. In the `caseAssistId` field, enter your [Case Assist Id](https://docs.coveo.com/en/3328/#retrieving-a-case-assist-id), retrieved from your Case Assist Configuration.
-   1. In the `engineId` field, enter your [Engine Id](https://docs.coveo.com/en/quantic/latest/reference/case-assist-components/case-assist-case-assist-interface/#properties), which is the name you want to give to the engine instance the Quantic components will register to.
-   1. Leave the `caseData` field blank.
+   2. In the `engineId` field, enter your [Engine Id](https://docs.coveo.com/en/quantic/latest/reference/case-assist-components/case-assist-case-assist-interface/#properties), which is the name you want to give to the engine instance the Quantic components will register to.
+   3. In the `searchHub` field, enter your Case Assist configuration name, retrieved from your Case Assist Configuration page.
+   4. Leave the `caseData` field blank.
 3. After linking your installed Coveo for Salesforce package to a Coveo organization, make sure to go change the content of the Apex class `CaseAssistController`. By default it will try to query a sample organization. Replace this method with the commented method just below it to generate a Platform token and query your selected Coveo organization.
 4. In the published version of your community, users can now fill in the Subject and Description fields on the first screen. They can then proceed to the next screens to view the predicted classification values for their case, and get document suggestions to help them potentially resolve their case before submitting it.
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,7 +7,7 @@
     {
       "path": "src/main/default",
       "package": "Salesforce Quantic Case Assist Cookbook",
-      "versionName": "Version 2.0.2",
+      "versionName": "Version 2.0.3",
       "versionNumber": "2.0.0.NEXT",
       "default": false,
       "dependencies": [
@@ -23,6 +23,6 @@
   "packageAliases": {
     "Quantic v2.25.0.0": "04t6g000008b3HkAAI",
     "Salesforce Quantic Case Assist Cookbook": "0Ho3s0000008OM7CAM",
-    "Salesforce Quantic Case Assist Cookbook@2.0.0-2": "04tKg000000kZt7IAE"
+    "Salesforce Quantic Case Assist Cookbook@2.0.0-3": "04tKg000000kZtRIAU"
   }
 }

--- a/src/main/default/flows/Demo_Flow.flow-meta.xml
+++ b/src/main/default/flows/Demo_Flow.flow-meta.xml
@@ -193,8 +193,5 @@
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>false</isOutput>
-        <value>
-            <stringValue>case-assist-cookbook</stringValue>
-        </value>
     </variables>
 </Flow>

--- a/src/main/default/flows/Recommended_Flow.flow-meta.xml
+++ b/src/main/default/flows/Recommended_Flow.flow-meta.xml
@@ -224,8 +224,5 @@
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>false</isOutput>
-        <value>
-            <stringValue>case-assist-cookbook</stringValue>
-        </value>
     </variables>
 </Flow>

--- a/src/main/default/lwc/createCaseScreen/createCaseScreen.js-meta.xml
+++ b/src/main/default/lwc/createCaseScreen/createCaseScreen.js-meta.xml
@@ -10,7 +10,7 @@
     <targetConfig targets="lightning__FlowScreen">
       <property name="caseData" label="Data from the case" type="String" />
       <property name="engineId" label="The ID of the engine instance the component registers to" type="String" />
-      <property name="searchHub" label="The identifier of the graphical case assist interface" type="String" default="case-assist-cookbook" />
+      <property name="searchHub" label="The identifier of the graphical case assist interface" type="String" />
       <property name="caseAssistId" label="The Case Assist configuration ID" type="String" />
     </targetConfig>
   </targetConfigs>

--- a/src/main/default/lwc/describeProblemScreen/describeProblemScreen.js-meta.xml
+++ b/src/main/default/lwc/describeProblemScreen/describeProblemScreen.js-meta.xml
@@ -10,7 +10,7 @@
     <targetConfig targets="lightning__FlowScreen">
       <property name="caseData" label="Data from the case" type="String" />
       <property name="engineId" label="The ID of the engine instance the component registers to" type="String" />
-      <property name="searchHub" label="The identifier of the graphical case assist interface" type="String" default="case-assist-cookbook" />
+      <property name="searchHub" label="The identifier of the graphical case assist interface" type="String" />
       <property name="caseAssistId" label="The Case Assist configuration ID" type="String" />
     </targetConfig>
   </targetConfigs>


### PR DESCRIPTION
## [SFINT-5981](https://coveord.atlassian.net/browse/SFINT-5981)

-  New version of the Case Assist Cookbook package created.
- In this version I removed the default value we used to set for the search hub, the search hub needs to be set by the end user and it needs to correspond to the case assist configuration name.
- Update the instructions in the read me.

[SFINT-5981]: https://coveord.atlassian.net/browse/SFINT-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ